### PR TITLE
[ 김인석 ] 아무때나 자원 갱신 핸들러 완성

### DIFF
--- a/src/components/ActionBoard.js
+++ b/src/components/ActionBoard.js
@@ -27,7 +27,6 @@ function ActionBoard({ data, setData }) {
   const [isTurn, setIsTurn] = useState(false);
   const [mainModalVisible, setMainModalVisible] = useState(false);
   const [subModalVisible, setSubModalVisible] = useState(false);
-  const [isAlways, setIsAlways] = useState(1);
   const [scoreBoardVisible, setScoreBoardVisible] = useState(true);
   const [mainSulbi, setMainSulbi] = useState([1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
   const [subSulbi, setSubSulbi] = useState([
@@ -84,7 +83,7 @@ function ActionBoard({ data, setData }) {
   }, [farmData.action]);
 
   const alwaysActHandler = async (res) => {
-    await updateAlways(farmData.turn); // 첫 놈 제외 갱신
+    await updateAlways(farmData.turn); // 누른 놈 제외 갱신
     sendingClient.current.send(
       "/main-board/resource/update",
       {},
@@ -107,31 +106,25 @@ function ActionBoard({ data, setData }) {
         food: res.food,
       })
     );
-    if(isAlways === 1){ // 최초에 한번만 실행
-      setIsAlways(0);
-      setTimeout(() => {
-        console.log("셋유저데이타");
-        setUserData((prevUserData) => ({
-          ...prevUserData,
-          [`user${farmData.turn}`]: {
-            ...prevUserData[`user${farmData.turn}`],
-            tree: prevUserData[`user${farmData.turn}`].tree + res.tree,
-            soil: prevUserData[`user${farmData.turn}`].soil + res.soil,
-            reed: prevUserData[`user${farmData.turn}`].reed + res.reed,
-            charcoal: prevUserData[`user${farmData.turn}`].charcoal + res.charcoal,
-            sheep: prevUserData[`user${farmData.turn}`].sheep + res.sheep,
-            pig: prevUserData[`user${farmData.turn}`].pig + res.pig,
-            cow: prevUserData[`user${farmData.turn}`].cow + res.cow,
-            grain: prevUserData[`user${farmData.turn}`].grain + res.grain,
-            vegetable: prevUserData[`user${farmData.turn}`].vegetable + res.vegetable,
-            food: prevUserData[`user${farmData.turn}`].food + res.food,
-          },
-        }));
-      }, 300);
+    if(farmData.action[20][1] === farmData.turn){ // 누른 사람은 갱신이 안되어있으므로 따로 갱신해줌
+      setUserData((prevUserData) => ({
+        ...prevUserData,
+        [`user${farmData.turn}`]: {
+          ...prevUserData[`user${farmData.turn}`],
+          tree: prevUserData[`user${farmData.turn}`].tree + res.tree,
+          soil: prevUserData[`user${farmData.turn}`].soil + res.soil,
+          reed: prevUserData[`user${farmData.turn}`].reed + res.reed,
+          charcoal: prevUserData[`user${farmData.turn}`].charcoal + res.charcoal,
+          sheep: prevUserData[`user${farmData.turn}`].sheep + res.sheep,
+          pig: prevUserData[`user${farmData.turn}`].pig + res.pig,
+          cow: prevUserData[`user${farmData.turn}`].cow + res.cow,
+          grain: prevUserData[`user${farmData.turn}`].grain + res.grain,
+          vegetable: prevUserData[`user${farmData.turn}`].vegetable + res.vegetable,
+          food: prevUserData[`user${farmData.turn}`].food + res.food,
+        },
+      }));
     }
-    
-    
-    
+
     console.log("always");
   };
 

--- a/src/components/Users.js
+++ b/src/components/Users.js
@@ -14,7 +14,7 @@ function Users() {
   }, [farmData.currentTurn]);
 
   useEffect(() => {
-    userDataUpdate2();
+      userDataUpdate2();
   }, [farmData.action[20][0]]);
 
 
@@ -114,9 +114,9 @@ function Users() {
 
   async function userDataUpdate2() {
     const userId = farmData.action[20][1];
-    console.log("실행중");
+    const userIndex = farmData.turn;
     console.log(userId);
-    if (userId === 3) {
+    if (userId === 3 && userIndex !== 3) {
       await setUserData((prevUserData) => ({
         ...prevUserData,
         user3: {
@@ -136,7 +136,7 @@ function Users() {
           farmer: farmData.farmer_count[2],
         },
       }));
-    } else if (userId === 4) {
+    } else if (userId === 4 && userIndex !== 4) {
       await setUserData((prevUserData) => ({
         ...prevUserData,
         user4: {
@@ -156,7 +156,7 @@ function Users() {
           farmer: farmData.farmer_count[3],
         },
       }));
-    } else if (userId === 1) {
+    } else if (userId === 1 && userIndex !== 1) {
       await setUserData((prevUserData) => ({
         ...prevUserData,
         user1: {
@@ -176,7 +176,7 @@ function Users() {
           farmer: farmData.farmer_count[0],
         },
       }));
-    } else {
+    } else if (userId === 2 && userIndex !== 2){
       await setUserData((prevUserData) => ({
         ...prevUserData,
         user2: {

--- a/src/store/data-context.js
+++ b/src/store/data-context.js
@@ -131,7 +131,7 @@ function DataContextProvider({ children }) {
     const updatedAlways = [...farmData.action];
     updatedAlways[20][1] = id;
     updatedAlways[20][0] += 1; // 배열 변경함
-    console.log("업뎃중");
+    console.log("업뎃하니까 갱신해주세요");
     await setFarmData((prevFarmData) => ({
       ...prevFarmData,
       action: updatedAlways, 


### PR DESCRIPTION
## 작업내용
- 아무때나 자원 갱신 핸들러 완성
<br>

## 주요 변경점
- 이전 버전에서는 시나리오를 다 짜야했으나 이제는 어떠한 경우에도 가능합니다. 다만 버그가 있어요.
<br>

## 유의할 점 (optional)
- 최초에 아무때나 로직 실행 시 이유는 모르겠으나 다른 유저가 보기에 누른 사람의 농부가 하나 깎임<br>(제일 처음부터 아무때나를 실행하지는 않으니까 상관없을듯?)
- 1 행동하기 >> 2 차례에서 1 아무때나 >> 2 행동하기 를 하면 2 농부수가 차감이 안됨.<br>(왜일까? 이거처럼 농부수가 차감이 안되는 버그가 있음.)
- 처음에 1이 아무떄나 실행하면 4도 같이 반영됨. (아마 4에서 이닛 메시지 안받아서 그런것으로 추정)
- 유저 4만 데이터 갱신이 어긋나는 경우가 있음. (얘도 아마 4에서 이닛 메시지 안받아서 그런것으로 추정)
<br>

## To Reviewers (optional)
- 이제 아무때나 관련 카드들 마구 생산하셔도 됩니다. 혹시 위에 유의할 점 이유 아시는 분 있으면 알려주세요 !
