### PR TITLE
Feat: 수확 - 가족 부양하기 부분 추가

### DIFF
--- a/src/components/ActionBoard.css
+++ b/src/components/ActionBoard.css
@@ -178,9 +178,16 @@
   cursor: pointer; /* 기본 커서를 포인터로 설정 */
 }
 
-.harvestBtn {
+.harvest_familyBtn {
   position: absolute;
-  top: -75px;
+  top: -50px;
   left: 500px;
+  cursor: pointer; /*기본 커서를 포인터로 설정 */
+}
+
+.harvest_grainBtn {
+  position: absolute;
+  top: -50px;
+  left: 600px;
   cursor: pointer; /*기본 커서를 포인터로 설정 */
 }

--- a/src/components/ActionBoard.js
+++ b/src/components/ActionBoard.js
@@ -53,7 +53,6 @@ function ActionBoard({ data, setData }) {
     farmData,
     setFarmData,
     updateFarmerCount,
-    updateFarmerCount_harvest,
     updateFarmData,
     updateAction,
     updateAlways,
@@ -977,16 +976,43 @@ function ActionBoard({ data, setData }) {
     }
   }
   //수확
-  function harvest() {
-    let a = 20;
-    let b = 1;
-    console.log(b);
-    if (b < 5) {
+  
+  function harvest_family() {
+    //
+    if (
+      userData[`user${farmData.turn}`].farmer === 2
+    ) {
+      // console.log(farmData.currentTurn);
+      // console.log(farmData.turn);
+      // console.log(userData[`user${farmData.turn}`].farmer);
       if (
         userData[`user${farmData.turn}`].food >=
         userData[`user${farmData.turn}`].farmer * 2
       ) {
+        const res = {
+          tree: 0,
+          soil: 0,
+          reed: 0,
+          charcoal: 0,
+          sheep: 0,
+          pig: 0,
+          cow: 0,
+          grain: 0,
+          vegetable: 0,
+          food: userData[`user${farmData.turn}`].farmer * 2 * -1,
+        };
+        defaultActHandler(res, 21);
+      } else {
+        console.log("구걸카드 띄워주기");
       }
+    }
+  }
+
+  function harvest_grain() {
+    if (
+      userData[`user${farmData.turn}`].farmer === 1
+    ) {
+      console.log("이제 여기 하면 끝");
     }
   }
 
@@ -1067,24 +1093,24 @@ function ActionBoard({ data, setData }) {
       {isBake && returnBakeDiv()}
       {returnBakeDiv()}
       <Board className="round" />
-      {isTurn && farmData.round < 7 && (
+      {isTurn && farmData.round < 6 && (
         <h2 style={{ position: "absolute", top: "-75px", left: "160px" }}>
           Your Turn!
         </h2>
       )}
 
-      {farmData.round === 6 && (
+      {farmData.round === 5 && (
         <h2 style={{ position: "absolute", top: "-75px", left: "300px" }}>
           Harvest
         </h2>
       )}
-      {farmData.round === 7 && (
+      {farmData.round === 6 && (
         <h2 style={{ position: "absolute", top: "-75px", left: "160px" }}>
           Game Over!
         </h2>
       )}
 
-      {farmData.round === 7 && scoreBoardVisible && (
+      {farmData.round === 6 && scoreBoardVisible && (
         <ScoreBoard setIsVisible={setScoreBoardVisible} />
       )}
 
@@ -1235,9 +1261,15 @@ function ActionBoard({ data, setData }) {
         <div className="player actionBtn3 theater">{moveOtherPlayer(15)}</div>
       )}
       {/*수확 버튼*/}
-      {isTurn && (farmData.round === 6 || farmData.round === 7) && (
-        <button className="harvestBtn" onClick={harvest}>
-          수확
+      {isTurn && (farmData.round === 5) && (
+        <button className="harvest_familyBtn" onClick={harvest_family}>
+          가족 부양
+        </button>
+      )}
+
+      {isTurn && (farmData.round === 5) &&  (
+        <button className="harvest_grainBtn" onClick={harvest_grain}>
+          작물 뿌려주기
         </button>
       )}
 

--- a/src/store/data-context.js
+++ b/src/store/data-context.js
@@ -36,6 +36,8 @@ function DataContextProvider({ children }) {
       [0, 1],
 
       [0, 0],
+      [0, 0],
+      [0,0],
     ],
 
     tree: 0,


### PR DESCRIPTION
## 작업내용
<br>수확 파트 중 하나인 가족 부양하기 부분 추가했습니다.
<br>수확 라운드인 5부터 시작하구요.
<br>수확 중간에 alwaysacthandler를 사용하는 카드들이 있어서 자동으로 턴을 넘기면 이 카드들을 쓸 타이밍을 잡기가 어려울 거 같아서 버튼을 추가하였습니당.
<br>가족 부양하기 부분은 농부 수가 2 일 때만 작동하고 모든 유저가 가족 부양하기를 하면 농부수가 1이 됩니다.
<br>1이 되면 작물 뿌려주기 부분 로직을 수행할 수 있도록 할 계획입니다.

## 주요 변경점
- 주요 변경사항에 대해 적어주세요.
<br>

## 유의할 점 (optional)
- 팀원이 유의해야할 변경 사항이나 로직이 생겼다면 적어주세요.
<br>

## To Reviewers (optional)
- 리뷰어에게 부탁할 내용(ex.~부분 도움 부탁합니다, ~부분 한 번 더 검토 부탁드려요) 이 있다면 적어주세요.
