### PR TITLE
[양재혁] 수확 턴 부터 라운드 카드 클릭 방지 기능 추가

### DIFF
--- a/src/components/ActionBoard.js
+++ b/src/components/ActionBoard.js
@@ -1254,7 +1254,7 @@ function ActionBoard({ data, setData }) {
         />
       )}
       {farmData.round >= 1 &&
-        (isTurn ? (
+        (isTurn && farmData.round <5 ? (
           <button
             className="actionBtn roundBtn1"
             onClick={() => facilityHandler(16)}
@@ -1264,13 +1264,12 @@ function ActionBoard({ data, setData }) {
           </button>
         ) : (
           <button className="player roundBtn1">
-            {moveOtherPlayer(16)}
             <Facility className="facilityBtn1" />
           </button>
         ))}
 
       {farmData.round >= 2 &&
-        (isTurn ? (
+        (isTurn && farmData.round<5? (
           <button
             className="actionBtn roundBtn2"
             onClick={() => fenceHandler(17)}
@@ -1280,13 +1279,12 @@ function ActionBoard({ data, setData }) {
           </button>
         ) : (
           <button className="player roundBtn2">
-            {moveOtherPlayer(17)}
             <Fence className="facilityBtn1" />
           </button>
         ))}
 
       {farmData.round >= 3 &&
-        (isTurn ? (
+        (isTurn &&farmData.round<5? (
           <button
             className="actionBtn roundBtn3"
             onClick={() => roundGrainHandler(18)}
@@ -1296,13 +1294,12 @@ function ActionBoard({ data, setData }) {
           </button>
         ) : (
           <button className="player roundBtn3">
-            {moveOtherPlayer(18)}
             <Grain className="facilityBtn1" />
           </button>
         ))}
 
       {farmData.round >= 4 &&
-        (isTurn ? (
+        (isTurn &&farmData.round<5? (
           <button
             className="actionBtn roundBtn4"
             onClick={() => sheepHandler(19)}
@@ -1312,7 +1309,6 @@ function ActionBoard({ data, setData }) {
           </button>
         ) : (
           <button className="player roundBtn4">
-            {moveOtherPlayer(19)}
             <Sheep className="facilityBtn1" />
           </button>
         ))}


### PR DESCRIPTION
## 작업내용
- 작업 내용을 적어주세요.
<br>수확 부터는 가족 부양 및 작물 뿌려주기만 가능해야 하므로 라운드 카드 클릭을 막아두었습니다.

## 주요 변경점
- 주요 변경사항에 대해 적어주세요.
<br>

## 유의할 점 (optional)
- 팀원이 유의해야할 변경 사항이나 로직이 생겼다면 적어주세요.
<br>

## To Reviewers (optional)
- 리뷰어에게 부탁할 내용(ex.~부분 도움 부탁합니다, ~부분 한 번 더 검토 부탁드려요) 이 있다면 적어주세요.
이제 가족 부양 시 식량 부족하면 구걸 카드 주기, 메인 설비 부분 하도록 하겠습니다.